### PR TITLE
add middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +94,22 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
 
 [[package]]
 name = "async-trait"
@@ -276,6 +307,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +351,8 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -315,6 +369,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "axum",
+ "axum-extra",
  "chrono",
  "http-body-util",
  "jwt-simple",
@@ -325,8 +380,11 @@ dependencies = [
  "sqlx-db-tester",
  "thiserror 2.0.4",
  "tokio",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -415,6 +473,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -635,6 +702,16 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1218,6 +1295,15 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2549,6 +2635,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,6 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -3097,4 +3204,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/chat_server/Cargo.toml
+++ b/chat_server/Cargo.toml
@@ -29,3 +29,7 @@ jwt-simple = { version = "0.12", default-features = false, features = [
 serde_json = "1.0.133"
 sqlx-db-tester = "0.5.0"
 http-body-util = "0.1.1"
+tower = "0.5.1"
+tower-http = { version = "0.6.2", features = ["compression-full", "trace"] }
+uuid = { version = "1.11.0", features = ["v7", "serde"] }
+axum-extra = { version = "0.9.6", features = ["typed-header"] }

--- a/chat_server/src/handlers/chat.rs
+++ b/chat_server/src/handlers/chat.rs
@@ -1,6 +1,8 @@
-use axum::response::IntoResponse;
-
-pub(crate) async fn list_char_handler() -> impl IntoResponse {
+use crate::User;
+use axum::{response::IntoResponse, Extension};
+use tracing::info;
+pub(crate) async fn list_chat_handler(Extension(user): Extension<User>) -> impl IntoResponse {
+    info!("user: {:?}", user);
     "list_char"
 }
 

--- a/chat_server/src/lib.rs
+++ b/chat_server/src/lib.rs
@@ -1,18 +1,21 @@
 mod config;
 mod error;
 mod handlers;
+mod middlewares;
 mod models;
 mod utils;
-
 use anyhow::Context;
 use axum::{
+    middleware::from_fn_with_state,
     routing::{get, patch, post},
     Router,
 };
 pub use config::AppConfig;
 pub use error::AppError;
 use handlers::*;
+use middlewares::{set_layer, verify_token};
 pub use models::User;
+
 pub use utils::jwt::{DecodingKey, EncodingKey};
 
 use core::fmt;
@@ -31,19 +34,21 @@ pub(crate) struct AppStateInner {
 pub async fn get_router(config: AppConfig) -> Result<Router, AppError> {
     let state = AppState::try_new(config).await?;
     let api = Router::new()
-        .route("/signin", post(signin_handler))
-        .route("/signup", post(signup_handler))
-        .route("/chat", get(list_char_handler).post(create_chat_handler))
+        .route("/chat", get(list_chat_handler).post(create_chat_handler))
         .route(
             "/chat/:id",
             patch(update_chat_handler).delete(delete_chat_handler),
         )
-        .route("/chat/:id/messages", get(list_messages_handler));
+        .route("/chat/:id/messages", get(list_messages_handler))
+        .layer(from_fn_with_state(state.clone(), verify_token))
+        .route("/signin", post(signin_handler))
+        .route("/signup", post(signup_handler));
+
     let app = Router::new()
         .route("/", get(index_handler))
         .nest("/api", api)
         .with_state(state);
-    Ok(app)
+    Ok(set_layer(app))
 }
 
 impl Deref for AppState {

--- a/chat_server/src/middlewares/auth.rs
+++ b/chat_server/src/middlewares/auth.rs
@@ -1,0 +1,42 @@
+use axum::{
+    extract::{FromRequestParts, Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use axum_extra::{
+    headers::{authorization::Bearer, Authorization},
+    TypedHeader,
+};
+use tracing::warn;
+
+use crate::AppState;
+
+pub async fn verify_token(State(state): State<AppState>, req: Request, next: Next) -> Response {
+    let (mut parts, body) = req.into_parts();
+    let req =
+        match TypedHeader::<Authorization<Bearer>>::from_request_parts(&mut parts, &state).await {
+            Ok(TypedHeader(Authorization(bearer))) => {
+                let token = bearer.token();
+                match state.dk.verify(token) {
+                    Ok(user) => {
+                        let mut req = Request::from_parts(parts, body);
+                        req.extensions_mut().insert(user);
+                        req
+                    }
+                    Err(e) => {
+                        let msg = format!("verify token failed: {}", e);
+                        warn!(msg);
+                        return (StatusCode::FORBIDDEN, msg).into_response();
+                    }
+                }
+            }
+
+            Err(e) => {
+                let msg = format!("parse Authorization header failed: {}", e);
+                warn!(msg);
+                return (StatusCode::UNAUTHORIZED, msg).into_response();
+            }
+        };
+    next.run(req).await
+}

--- a/chat_server/src/middlewares/mod.rs
+++ b/chat_server/src/middlewares/mod.rs
@@ -1,0 +1,36 @@
+use axum::{middleware::from_fn, Router};
+use request_id::set_request_id;
+use server_time::ServerTime;
+use tower::ServiceBuilder;
+use tower_http::{
+    compression::CompressionLayer,
+    trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
+    LatencyUnit,
+};
+use tracing::Level;
+const SERVER_TIME_HEADER: &str = "x-server-time";
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+pub use auth::verify_token;
+
+mod auth;
+mod request_id;
+mod server_time;
+pub fn set_layer(app: Router) -> Router {
+    app.layer(
+        ServiceBuilder::new()
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(DefaultMakeSpan::new().include_headers(true))
+                    .on_request(DefaultOnRequest::new().level(Level::INFO))
+                    .on_response(
+                        DefaultOnResponse::new()
+                            .level(Level::INFO)
+                            .latency_unit(LatencyUnit::Micros),
+                    ),
+            )
+            .layer(CompressionLayer::new().gzip(true).br(true).deflate(true))
+            .layer(from_fn(set_request_id))
+            .layer(ServerTime),
+    )
+}

--- a/chat_server/src/middlewares/request_id.rs
+++ b/chat_server/src/middlewares/request_id.rs
@@ -1,0 +1,30 @@
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
+use tracing::warn;
+
+use super::REQUEST_ID_HEADER;
+
+pub async fn set_request_id(mut req: Request, next: Next) -> Response {
+    // if x-request-id exists, do nothing, otherwise generate a new one
+    let id = match req.headers().get(REQUEST_ID_HEADER) {
+        Some(v) => Some(v.clone()),
+        None => {
+            let request_id = uuid::Uuid::now_v7().to_string();
+            match HeaderValue::from_str(&request_id) {
+                Ok(v) => {
+                    req.headers_mut().insert(REQUEST_ID_HEADER, v.clone());
+                    Some(v)
+                }
+                Err(e) => {
+                    warn!("parse generated request id failed: {}", e);
+                    None
+                }
+            }
+        }
+    };
+    let mut res = next.run(req).await;
+    let Some(id) = id else {
+        return res;
+    };
+    res.headers_mut().insert(REQUEST_ID_HEADER, id);
+    res
+}

--- a/chat_server/src/middlewares/server_time.rs
+++ b/chat_server/src/middlewares/server_time.rs
@@ -1,0 +1,69 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::{extract::Request, response::Response};
+use tower::{Layer, Service};
+use tracing::warn;
+
+use crate::middlewares::REQUEST_ID_HEADER;
+
+use super::SERVER_TIME_HEADER;
+
+#[derive(Clone)]
+pub struct ServerTime;
+
+impl<S> Layer<S> for ServerTime {
+    type Service = ServerTimeMiddleWare<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ServerTimeMiddleWare { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct ServerTimeMiddleWare<S> {
+    inner: S,
+}
+
+impl<S> Service<Request> for ServerTimeMiddleWare<S>
+where
+    S: Service<Request, Response = Response> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    // `BoxFuture` is a type alias for `Pin<Box<dyn Future + Send + 'a>>`
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let start = tokio::time::Instant::now();
+        let future = self.inner.call(request);
+        Box::pin(async move {
+            let mut response: Response = future.await?;
+            let elapsed = format!("{}us", start.elapsed().as_micros());
+
+            match elapsed.parse() {
+                Ok(v) => {
+                    response.headers_mut().insert(SERVER_TIME_HEADER, v);
+                }
+                Err(e) => {
+                    warn!(
+                        "Parse elapsed time failed: {} for request {:?}",
+                        e,
+                        response.headers().get(REQUEST_ID_HEADER)
+                    );
+                }
+            }
+
+            Ok(response)
+        })
+    }
+}

--- a/test.rest
+++ b/test.rest
@@ -1,30 +1,29 @@
 ### signup user
 
-POST http://localhost:6688/api/signup
-Content-Type: application/json
+POST http://localhost:6688/api/signup Content-Type: application/json
 
 {
-    "username": "Alice Chen",
-    "email": "alice@acme.org",
-    "password": "123456"
+"fullname": "Alice Chen", "email": "alice@acme.org", "password": "123456"
 }
 
 ### signin user (valid)
 
-POST http://localhost:6688/api/signin
-Content-Type: application/json
+POST http://localhost:6688/api/signin Content-Type: application/json
 
 {
-    "email": "tchen@acme.org",
-    "password": "123456"
+"email": "tchen@acme.org", "password": "123456"
 }
 
 ### signin user (invalid)
 
-POST http://localhost:6688/api/signin
-Content-Type: application/json
+# @name signin POST http://localhost:6688/api/signin Content-Type: application/json
 
 {
-    "email": "alice@acme.org",
-    "password": "123456"
+"email": "alice@acme.org", "password": "123456"
 }
+
+@token = {{signin.response.body.token}}
+
+### get chat list
+
+GET http://localhost:6688/api/chat Authorization: Bearer {{token}}


### PR DESCRIPTION
This pull request introduces several changes to the `chat_server` module, focusing on adding middleware, enhancing request handling, and updating dependencies. The most important changes are summarized below:

### Middleware Enhancements:

* Added `verify_token` middleware to authenticate requests using JWT tokens. This middleware extracts the token from the request headers, verifies it, and attaches the user to the request context. (`chat_server/src/middlewares/auth.rs`)
* Introduced `set_request_id` middleware to generate and attach a unique request ID to each request if not already present. (`chat_server/src/middlewares/request_id.rs`)
* Implemented `ServerTime` middleware to measure and attach the server processing time to the response headers. (`chat_server/src/middlewares/server_time.rs`)

### Dependency Updates:

* Updated `Cargo.toml` to include new dependencies: `tower`, `tower-http`, `uuid`, and `axum-extra`. (`chat_server/Cargo.toml`)

### Request Handling Improvements:

* Modified the `list_chat_handler` to log user information and use the `Extension` extractor for user context. (`chat_server/src/handlers/chat.rs`)
* Updated the router configuration to apply the new middlewares and reorganized routes for better clarity. (`chat_server/src/lib.rs`) [[1]](diffhunk://#diff-5040fe2667fc35260ff76d00dd5fe506e5ae4d6c75515e97fcc280ad440558e7R4-R18) [[2]](diffhunk://#diff-5040fe2667fc35260ff76d00dd5fe506e5ae4d6c75515e97fcc280ad440558e7L34-R51)

### Test Adjustments:

* Adjusted the `test.rest` file to reflect changes in the API endpoints and added a new test for the chat list endpoint with authorization. (`test.rest`)

These changes collectively enhance the security, traceability, and performance monitoring of the `chat_server` module.